### PR TITLE
Remove "transact" from Yjs integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ But not everything is cute puppies and warm bread and butter in CRDT-land.
 
 CRDTs (and local writes) are amazing until... you need a server (it happens).
 
-### Common reasons for needing a server:
+### Common reasons for needing a server when building with CRDTs:
 
 #### Only a server can run the code:
 

--- a/README.md
+++ b/README.md
@@ -82,19 +82,15 @@ const appRouter = router({
     .mutation(async (opts) => {
       const {
         input,
-        ctx: { users, transact, response },
+        ctx: { users, response },
       } = opts
       const user = { ..input }
 
-      // Writes in the transact function gets applied at same time the trpc call
-      // is finished.
-      transact(() => {
-        // Set new user on the Y.Map users.
-        users.set(user.id, user)
-        // "response" is a Y.Map that you can write to at any point in the call.
-        // Perfect for sending progress updates on long running jobs, etc.
-        response.set(`ok`, true)
-      })
+      // Set new user on the Y.Map users.
+      users.set(user.id, user)
+      // "response" is a Y.Map that you can write to at any point in the call.
+      // Perfect for sending progress updates on long running jobs, etc.
+      response.set(`ok`, true)
     })
 })
 

--- a/examples/yjs/app/routes/_index.tsx
+++ b/examples/yjs/app/routes/_index.tsx
@@ -124,7 +124,7 @@ function RecentCallsTable({ doc }) {
           <TableHead className="w-[100px]">path</TableHead>
           <TableHead>input</TableHead>
           <TableHead>elapsedMs</TableHead>
-          <TableHead>done</TableHead>
+          <TableHead>state</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -133,7 +133,7 @@ function RecentCallsTable({ doc }) {
             <TableCell className="font-medium">{call.path}</TableCell>
             <TableCell>{JSON.stringify(call.input)}</TableCell>
             <TableCell>{call.elapsedMs}</TableCell>
-            <TableCell>{JSON.stringify(call.done)}</TableCell>
+            <TableCell>{JSON.stringify(call.state)}</TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/examples/yjs/server/trpc.ts
+++ b/examples/yjs/server/trpc.ts
@@ -19,7 +19,7 @@ export const appRouter = router({
     .mutation(async (opts) => {
       const {
         input,
-        ctx: { users, transact },
+        ctx: { users },
       } = opts
       const user = { id: String(users.length + 1), ...input }
 
@@ -34,18 +34,14 @@ export const appRouter = router({
         })
       }
 
-      // Run in transaction along with setting response on the request
-      // object.
-      transact(() => {
-        users.push([user])
-      })
+      users.push([user])
     }),
   userUpdateName: publicProcedure
     .input(z.object({ id: z.string(), name: z.string() }))
     .mutation(async (opts) => {
       const {
         input,
-        ctx: { users, transact },
+        ctx: { users },
       } = opts
       let user
       let id
@@ -57,12 +53,8 @@ export const appRouter = router({
       })
       const newUser = { ...user, name: input.name }
 
-      // Run in transaction along with setting response on the request
-      // object.
-      transact(() => {
-        users.delete(id, 1)
-        users.insert(id, [newUser])
-      })
+      users.delete(id, 1)
+      users.insert(id, [newUser])
     }),
 })
 

--- a/packages/electric-sql/src/generated/client/index.ts
+++ b/packages/electric-sql/src/generated/client/index.ts
@@ -897,7 +897,7 @@ export const tableSchemas = {
       ],
       [
         "createdat",
-        "DATE"
+        "TIMESTAMPTZ"
       ],
       [
         "elapsedms",

--- a/packages/electric-sql/src/link.ts
+++ b/packages/electric-sql/src/link.ts
@@ -80,9 +80,13 @@ export const link = <TRouter extends AnyRouter>({
     }
   }
 
-  electricRef.subscribe((electric: any) =>
-    electric.notifier.subscribeToDataChanges(observe)
-  )
+  if (typeof electricRef.value === `undefined`) {
+    electricRef.subscribe((electric: any) =>
+      electric.notifier.subscribeToDataChanges(observe)
+    )
+  } else {
+    electricRef.value.notifier.subscribeToDataChanges(observe)
+  }
 
   return () =>
     ({ op }) =>

--- a/packages/yjs/README.md
+++ b/packages/yjs/README.md
@@ -58,19 +58,15 @@ const appRouter = router({
     .mutation(async (opts) => {
       const {
         input,
-        ctx: { users, transact, response },
+        ctx: { users, response },
       } = opts
       const user = { ..input }
 
-      // Writes in the transact function gets applied at same time the trpc call
-      // is finished.
-      transact(() => {
-        // Set new user on the Y.Map users.
-        users.set(user.id, user)
-        // "response" is a Y.Map that you can write to at any point in the call.
-        // Perfect for sending progress updates on long running jobs, etc.
-        response.set(`ok`, true)
-      })
+      // Set new user on the Y.Map users.
+      users.set(user.id, user)
+      // "response" is a Y.Map that you can write to at any point in the call.
+      // Perfect for sending progress updates on long running jobs, etc.
+      response.set(`ok`, true)
     })
 })
 

--- a/packages/yjs/index.test.ts
+++ b/packages/yjs/index.test.ts
@@ -41,7 +41,7 @@ function initClient() {
       .mutation(async (opts) => {
         const {
           input,
-          ctx: { users, transact, response },
+          ctx: { users, response },
         } = opts
         const user = { id: String(users.length + 1), ...input }
 
@@ -58,19 +58,15 @@ function initClient() {
           })
         }
 
-        // Run in transaction along with setting response on the request
-        // object.
-        transact(() => {
-          users.push([user])
-          response.set(`user`, user)
-        })
+        users.push([user])
+        response.set(`user`, user)
       }),
     userUpdateName: publicProcedure
       .input(z.object({ id: z.string(), name: z.string() }))
       .mutation(async (opts) => {
         const {
           input,
-          ctx: { users, transact, response },
+          ctx: { users, response },
         } = opts
         let user
         let id
@@ -82,13 +78,9 @@ function initClient() {
         })
         const newUser = { ...user, name: input.name }
 
-        // Run in transaction along with setting response on the request
-        // object.
-        transact(() => {
-          users.delete(id, 1)
-          users.insert(id, [newUser])
-          response.set(`user`, newUser)
-        })
+        users.delete(id, 1)
+        users.insert(id, [newUser])
+        response.set(`user`, newUser)
       }),
   })
 

--- a/packages/yjs/src/adapter.ts
+++ b/packages/yjs/src/adapter.ts
@@ -32,24 +32,15 @@ export function adapter({ appRouter, context, onError }: AdapterArgs) {
         return
       }
       if (state.get(`state`) === `WAITING`) {
-        const transactionFns: any[] = []
-        const transact = (fn: () => void) => {
-          transactionFns.push(fn)
-        }
         try {
           await callProcedure({
             procedures: appRouter._def.procedures,
             path: state.get(`path`),
             rawInput: state.get(`input`),
             type: state.get(`type`),
-            ctx: { ...context, transact, response: state.get(`response`) },
+            ctx: { ...context, response: state.get(`response`) },
           })
-          doc.transact(() => {
-            transactionFns.forEach((fn) => {
-              fn()
-            })
-            state.set(`state`, `DONE`)
-          })
+          state.set(`state`, `DONE`)
         } catch (cause) {
           const error = getTRPCErrorFromUnknown(cause)
           const errorShape = getErrorShape({


### PR DESCRIPTION
In real-world architectures, it's unlikely that the doc used for tracking trpc calls will be the same one used for data so it wouldn't be possible to maintain a transaction across docs.

In ElectricSQL, on the other hand, you will always be writing to the same system so keeping the transact function there makes sense so writes to various data structures + closing out the call happen at the same time.