### PR TITLE
Revert integrations to use normal tRPC semantics of just returning the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,14 @@ const appRouter = router({
     .mutation(async (opts) => {
       const {
         input,
-        ctx: { users, response },
+        ctx: { users },
       } = opts
       const user = { ..input }
 
       // Set new user on the Y.Map users.
       users.set(user.id, user)
-      // "response" is a Y.Map that you can write to at any point in the call.
-      // Perfect for sending progress updates on long running jobs, etc.
-      response.set(`ok`, true)
+
+      return `ok`
     })
 })
 

--- a/packages/electric-sql/src/adapter.ts
+++ b/packages/electric-sql/src/adapter.ts
@@ -58,24 +58,13 @@ export async function adapter({ appRouter, context, onError }: AdapterArgs) {
       transactionFns.push(fn)
     }
 
-    async function setResponse(responseObj: any) {
-      return db.trpc_calls.update({
-        data: {
-          response: JSON.stringify(responseObj),
-        },
-        where: {
-          id: callObj.id,
-        },
-      })
-    }
-
     try {
-      await callProcedure({
+      const response = await callProcedure({
         procedures: appRouter._def.procedures,
         path: callObj.path,
         rawInput: JSON.parse(callObj.input),
         type: callObj.type,
-        ctx: { ...context, transact, setResponse },
+        ctx: { ...context, transact },
       })
 
       const transactionPromises = transactionFns.map((fn) => fn())
@@ -87,6 +76,7 @@ export async function adapter({ appRouter, context, onError }: AdapterArgs) {
         db.trpc_calls.update({
           data: {
             state: `DONE`,
+            response: JSON.stringify(response),
           },
           where: {
             id: callObj.id,

--- a/packages/electric-sql/src/link.ts
+++ b/packages/electric-sql/src/link.ts
@@ -50,11 +50,6 @@ interface CallObj {
   id: string
 }
 
-interface InputWithCallId {
-  callId?: string
-  [key: string]: any
-}
-
 export const link = <TRouter extends AnyRouter>({
   electricRef,
   clientId,
@@ -92,19 +87,7 @@ export const link = <TRouter extends AnyRouter>({
     ({ op }) =>
       observable((observer) => {
         const { db } = electricRef.value
-        let callId: string
-        if (
-          typeof op.input === `object` &&
-          !Array.isArray(op.input) &&
-          op.input !== null &&
-          (op.input as InputWithCallId).callId !== undefined &&
-          Object.prototype.hasOwnProperty.call(op.input, `callId`)
-        ) {
-          callId = (op.input as InputWithCallId).callId || ``
-          delete (op.input as InputWithCallId).callId
-        } else {
-          callId = genUUID()
-        }
+        const callId = genUUID()
 
         callMap.set(callId, (callRes: CallObj) => {
           const elapsedMs = new Date().getTime() - callRes.createdat.getTime()

--- a/packages/yjs/README.md
+++ b/packages/yjs/README.md
@@ -58,15 +58,14 @@ const appRouter = router({
     .mutation(async (opts) => {
       const {
         input,
-        ctx: { users, response },
+        ctx: { users },
       } = opts
       const user = { ..input }
 
       // Set new user on the Y.Map users.
       users.set(user.id, user)
-      // "response" is a Y.Map that you can write to at any point in the call.
-      // Perfect for sending progress updates on long running jobs, etc.
-      response.set(`ok`, true)
+
+      return `ok`
     })
 })
 

--- a/packages/yjs/src/adapter.ts
+++ b/packages/yjs/src/adapter.ts
@@ -33,13 +33,14 @@ export function adapter({ appRouter, context, onError }: AdapterArgs) {
       }
       if (state.get(`state`) === `WAITING`) {
         try {
-          await callProcedure({
+          const response = await callProcedure({
             procedures: appRouter._def.procedures,
             path: state.get(`path`),
             rawInput: state.get(`input`),
             type: state.get(`type`),
-            ctx: { ...context, response: state.get(`response`) },
+            ctx: { ...context },
           })
+          state.set(`response`, response)
           state.set(`state`, `DONE`)
         } catch (cause) {
           const error = getTRPCErrorFromUnknown(cause)
@@ -62,7 +63,7 @@ export function adapter({ appRouter, context, onError }: AdapterArgs) {
 
           doc.transact(() => {
             state.set(`state`, `ERROR`)
-            state.get(`response`).set(`error`, { error: errorShape })
+            state.set(`response`, { error: errorShape })
           })
         }
       }

--- a/packages/yjs/src/link.ts
+++ b/packages/yjs/src/link.ts
@@ -39,19 +39,7 @@ export const link = <TRouter extends AnyRouter>({
     ({ op }) =>
       observable((observer) => {
         const calls = doc.getArray(`trpc-calls`)
-        let callId: string
-        if (
-          typeof op.input === `object` &&
-          !Array.isArray(op.input) &&
-          op.input !== null &&
-          (op.input as InputWithCallId).callId !== undefined &&
-          Object.prototype.hasOwnProperty.call(op.input, `callId`)
-        ) {
-          callId = (op.input as InputWithCallId).callId || ``
-          delete (op.input as InputWithCallId).callId
-        } else {
-          callId = uuidv4()
-        }
+        const callId = uuidv4()
         const callMap = new Map()
 
         // The observe function to listen to the response
@@ -66,14 +54,12 @@ export const link = <TRouter extends AnyRouter>({
                 new Date((callMap.get(`createdAt`) as number) || 0).getTime()
             )
             if (state.get(`state`) === `ERROR`) {
-              observer.error(
-                TRPCClientError.from(state.get(`response`).get(`error`))
-              )
+              observer.error(TRPCClientError.from(state.get(`response`)))
             } else if (state.get(`state`) === `DONE`) {
               observer.next({
                 result: {
                   type: `data`,
-                  data: state.get(`response`).toJSON(),
+                  data: state.get(`response`),
                 },
               })
             }

--- a/packages/yjs/src/link.ts
+++ b/packages/yjs/src/link.ts
@@ -25,11 +25,6 @@ function uuidv4() {
 // response: any
 // }
 
-interface InputWithCallId {
-  callId?: string
-  [key: string]: any
-}
-
 export const link = <TRouter extends AnyRouter>({
   doc,
 }: {


### PR DESCRIPTION
There's not a good reason to divert from tRPC semantics to add multiple responses. A call can start writing to another shared object e.g. the user to send in-progress updates if that's necessary.