### PR TITLE
fix: server not starting because public dir doesn't exist

### DIFF
--- a/examples/electric-sql/package.json
+++ b/examples/electric-sql/package.json
@@ -14,7 +14,7 @@
     "build": "echo 'build'",
     "dev": "node copy-wasm-files.js && remix watch",
     "start": "cross-env NODE_ENV=production node server/index.js",
-    "start:dev": "cross-env NODE_ENV=development concurrently \"npx tsx server/index.js\" \"pnpm run dev\"",
+    "start:dev": "mkdir -p public && cross-env NODE_ENV=development concurrently \"npx tsx server/index.js\" \"pnpm run dev\"",
     "typecheck": "tsc"
   },
   "keywords": [],


### PR DESCRIPTION
I faced the same exact issue as [them](https://github.com/KyleAMathews/trpc-crdt/issues/7). The solution he proposed works. We just need to create a public folder if it doesn't exist yet.

Currently `public` is listed in the .gitignore so the .gitkeep method he proposed wouldn't work here